### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2195,6 +2195,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.0-beta.153.tgz",
           "integrity": "sha512-aXweZ1Z7vMNzJdLpR1CZUAIgnwjrZeUSvN9syCwlBaEBUFJmFY+HHnfuTI5vIhVs/mRkfJVrbEyl51JZQqyjAg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/address": ">=5.0.0-beta.128",
             "@ethersproject/bignumber": ">=5.0.0-beta.130",
@@ -2212,6 +2213,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
           "integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -2227,6 +2229,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.10.tgz",
           "integrity": "sha512-irx7kH7FDAeW7QChDPW19WsxqeB1d3XLyOLSXm0bfPqL1SS07LXWltBJUBUxqC03ORpAOcM3JQj57DU8JnVY2g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/abstract-provider": "^5.0.8",
             "@ethersproject/bignumber": "^5.0.13",
@@ -2240,6 +2243,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
           "integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13",
             "@ethersproject/bytes": "^5.0.9",
@@ -2253,6 +2257,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
           "integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9"
           }
@@ -2262,6 +2267,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
           "integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -2273,6 +2279,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
           "integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -2282,6 +2289,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
           "integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bignumber": "^5.0.13"
           }
@@ -2291,6 +2299,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
           "integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/abstract-signer": "^5.0.10",
             "@ethersproject/address": "^5.0.9",
@@ -2307,6 +2316,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
           "integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "js-sha3": "0.5.7"
@@ -2316,13 +2326,15 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
           "integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "@ethersproject/networks": {
           "version": "5.0.7",
           "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
           "integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -2332,6 +2344,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
           "integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/logger": "^5.0.8"
           }
@@ -2341,6 +2354,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
           "integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8"
@@ -2351,6 +2365,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
           "integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/logger": "^5.0.8",
@@ -2363,6 +2378,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
           "integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/bytes": "^5.0.9",
             "@ethersproject/constants": "^5.0.8",
@@ -2374,6 +2390,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
           "integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/address": "^5.0.9",
             "@ethersproject/bignumber": "^5.0.13",
@@ -2391,6 +2408,7 @@
           "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
           "integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/base64": "^5.0.7",
             "@ethersproject/bytes": "^5.0.9",
@@ -2548,6 +2566,7 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
           "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.0.0",
             "inherits": "^2.0.1",
@@ -3450,7 +3469,8 @@
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
           "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bip39": {
           "version": "2.5.0",
@@ -3489,6 +3509,7 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -3507,6 +3528,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -3515,13 +3537,15 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "qs": {
               "version": "6.7.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
               "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3585,6 +3609,7 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
           "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^5.0.0",
             "randombytes": "^2.0.1"
@@ -3594,7 +3619,8 @@
               "version": "5.1.3",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
               "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -3687,7 +3713,8 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -3708,7 +3735,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -4095,7 +4123,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -4132,7 +4161,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -4276,6 +4306,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -4357,7 +4388,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -4374,7 +4406,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-indent": {
           "version": "4.0.0",
@@ -4416,7 +4449,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.2",
@@ -4432,7 +4466,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.636",
@@ -4459,7 +4494,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "encoding": {
           "version": "0.1.13",
@@ -4590,7 +4626,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -4608,7 +4645,8 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -5503,6 +5541,7 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
           "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           },
@@ -5511,7 +5550,8 @@
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
               "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6091,6 +6131,7 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -6100,7 +6141,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -6118,7 +6160,8 @@
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
           "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "events": {
           "version": "3.2.0",
@@ -6687,7 +6730,8 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "7.0.1",
@@ -7018,6 +7062,7 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -7030,7 +7075,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -7038,7 +7084,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -7056,6 +7103,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -7320,7 +7368,8 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
           "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "js-tokens": {
           "version": "4.0.0",
@@ -7422,6 +7471,16 @@
             "extsprintf": "1.3.0",
             "json-schema": "0.2.3",
             "verror": "1.10.0"
+          }
+        },
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "dev": true,
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "keyv": {
@@ -7623,7 +7682,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -7670,7 +7730,8 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -7743,7 +7804,8 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
           "version": "1.45.0",
@@ -7764,7 +7826,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -7893,6 +7956,7 @@
           "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
           "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer": "^5.5.0",
             "multibase": "^0.7.0",
@@ -7904,6 +7968,7 @@
               "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
               "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "base-x": "^3.0.8",
                 "buffer": "^5.5.0"
@@ -7986,6 +8051,7 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -7995,7 +8061,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8153,6 +8220,7 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -8162,6 +8230,7 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -8218,6 +8287,7 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
           "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "asn1.js": "^5.2.0",
             "browserify-aes": "^1.0.0",
@@ -8236,7 +8306,8 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -8522,6 +8593,7 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -8544,6 +8616,7 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -8574,13 +8647,15 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -8897,6 +8972,7 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -8918,6 +8994,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -8926,7 +9003,8 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -8934,7 +9012,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -9010,7 +9089,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -9026,13 +9106,15 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -9372,7 +9454,8 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "stream-to-pull-stream": {
           "version": "1.7.3",
@@ -9396,7 +9479,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string.prototype.trim": {
           "version": "1.2.3",
@@ -9653,6 +9737,7 @@
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
               "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9680,7 +9765,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -9740,7 +9826,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -9790,6 +9877,7 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -9842,7 +9930,8 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "union-value": {
           "version": "1.0.1",
@@ -9880,7 +9969,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -9951,7 +10041,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -9979,7 +10070,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -10017,13 +10109,15 @@
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
           "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "vary": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -10079,6 +10173,7 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
           "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
             "@types/node": "^12.12.6",
@@ -10093,7 +10188,8 @@
               "version": "12.19.12",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
               "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10102,6 +10198,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
           "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.11",
@@ -10113,6 +10210,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
           "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/transactions": "^5.0.0-beta.135",
             "underscore": "1.9.1",
@@ -10127,6 +10225,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
           "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4"
           }
@@ -10136,6 +10235,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
           "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.11",
@@ -10149,6 +10249,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
           "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
@@ -10182,6 +10283,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
           "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@ethersproject/abi": "5.0.0-beta.153",
             "underscore": "1.9.1",
@@ -10234,6 +10336,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
           "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
             "underscore": "1.9.1",
@@ -10269,6 +10372,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
           "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.11.9",
             "web3-utils": "1.2.11"
@@ -10279,6 +10383,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
           "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^12.12.6",
             "web3-core": "1.2.11",
@@ -10292,7 +10397,8 @@
               "version": "12.19.12",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
               "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10301,6 +10407,7 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
           "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.11",
             "web3-core-method": "1.2.11",
@@ -10359,7 +10466,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -10712,6 +10819,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
           "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.11",
             "xhr2-cookies": "1.1.0"
@@ -10722,6 +10830,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
           "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -10733,6 +10842,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
           "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "4.0.4",
             "underscore": "1.9.1",
@@ -10758,6 +10868,7 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
           "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "^4.11.9",
             "eth-lib": "0.2.8",
@@ -10774,6 +10885,7 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
               "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -10863,6 +10975,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -10878,6 +10991,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
           "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "xhr-request": "^1.1.0"
           }
@@ -10887,6 +11001,7 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }


### PR DESCRIPTION
Just noticed these changes while following the readme instructions. 

The `"optional": true` lines are probably minor since it is related with the npm version used. But the `keccak` might be relevant.

my local env:
❯ node -v
v14.2.0

❯ npm -v
6.14.4